### PR TITLE
New change 13/09/17

### DIFF
--- a/src/app/awards/awards.component.html
+++ b/src/app/awards/awards.component.html
@@ -29,7 +29,7 @@
             <p>{{award.SponsorName}}</p>
             <p>{{award.AwardName}}</p>
             <p>{{award.AwardSponsorBlurb}}</p>
-            <a href="{{award.SponsorLink | stripurl}}" target="_blank">{{award.SponsorLink | stripurl}}</a>
+            <p>{{award.SponsorLink}}</p>
           </md-card-content>
         </md-card>
       </div>

--- a/src/app/image-detail/image-detail.component.css
+++ b/src/app/image-detail/image-detail.component.css
@@ -1,9 +1,9 @@
 .img-container {
     margin:  auto;
-    margin-bottom: 50px;
+    margin-bottom: 0;
     box-shadow: #555 1px 2px 8px 1px;
-    height: 660px;
-    max-width: 900px;
+    /* height: 660px; */
+    max-width: 100%;
     background-position: center;
     background-repeat: no-repeat;
     align-content: center;
@@ -24,6 +24,7 @@
 }
 .border{
     margin: 20px;
+    margin-bottom: 50px;
     border: 4px solid #eee;
     border-radius: 2px;
     box-shadow: #555 1px 1px 8px 1px;

--- a/src/app/signsponsor/signsponsor.component.css
+++ b/src/app/signsponsor/signsponsor.component.css
@@ -112,3 +112,9 @@ input[type=checkbox]{
         transform: translateY(0);
     }
 }
+
+@media screen and (max-width: 415px){
+    .border{
+        margin-left: 0;
+    }
+}

--- a/src/app/sponsors/sponsors.component.css
+++ b/src/app/sponsors/sponsors.component.css
@@ -14,3 +14,7 @@
 button{
     margin:10px;
 }
+
+.card-deck .danger{
+    padding-left: 0%;
+}


### PR DESCRIPTION
Image Detail Component:
- No more of setting the height of image.
- Set the maximum of width of image is now 100%
- Margin for bottom is now set as 0.
- For iPhone 5 view issue, the margin-bottom of border is set as 50px.

Sign-up Sponsor Component:
- For mobile view, the margin-left is set as 0.

Sponsor Component:
- Padding-left for .card-deck .danger is now 0.
